### PR TITLE
Fix CTFd Check

### DIFF
--- a/cmd/ctfd-download.go
+++ b/cmd/ctfd-download.go
@@ -31,6 +31,8 @@ var ctfdDownloadCmd = &cobra.Command{
 		opts.Password = viper.GetString("password")
 		opts.Output = viper.GetString("output")
 		opts.Overwrite = viper.GetBool("overwrite")
+		opts.SaveConfig = viper.GetBool("save-config")
+		opts.SkipCTFDCheck = viper.GetBool("skip-check")
 
 		baseURL, err := url.Parse(opts.URL)
 		CheckErr(err)
@@ -61,8 +63,10 @@ var ctfdDownloadCmd = &cobra.Command{
 		client.Creds = &credentials
 		client.MaxFileSize = options.MaxFileSize
 
-		err = ctfd.Check()
-		CheckErr(err)
+		if !opts.SkipCTFDCheck {
+			err = ctfd.Check()
+			CheckErr(err)
+		}
 
 		err = ctfd.Authenticate()
 		CheckErr(err)

--- a/cmd/ctfd-download.go
+++ b/cmd/ctfd-download.go
@@ -61,6 +61,9 @@ var ctfdDownloadCmd = &cobra.Command{
 		client.Creds = &credentials
 		client.MaxFileSize = options.MaxFileSize
 
+		err = ctfd.Check()
+		CheckErr(err)
+
 		err = ctfd.Authenticate()
 		CheckErr(err)
 

--- a/cmd/ctfd-submit.go
+++ b/cmd/ctfd-submit.go
@@ -26,6 +26,7 @@ var ctfdSubmitCmd = &cobra.Command{
 		opts.URL = viper.GetString("url")
 		opts.Username = viper.GetString("username")
 		opts.Password = viper.GetString("password")
+		opts.SkipCTFDCheck = viper.GetBool("skip-check")
 
 		baseURL, err := url.Parse(opts.URL)
 		CheckErr(err)
@@ -63,8 +64,10 @@ var ctfdSubmitCmd = &cobra.Command{
 
 		client.Creds = &credentials
 
-		err = ctfd.Check()
-		CheckErr(err)
+		if !opts.SkipCTFDCheck {
+			err = ctfd.Check()
+			CheckErr(err)
+		}
 
 		err = ctfd.Authenticate()
 		CheckErr(err)

--- a/cmd/ctfd-submit.go
+++ b/cmd/ctfd-submit.go
@@ -63,6 +63,9 @@ var ctfdSubmitCmd = &cobra.Command{
 
 		client.Creds = &credentials
 
+		err = ctfd.Check()
+		CheckErr(err)
+
 		err = ctfd.Authenticate()
 		CheckErr(err)
 

--- a/cmd/ctfd-writeups.go
+++ b/cmd/ctfd-writeups.go
@@ -30,6 +30,7 @@ var ctfdWriteupCmd = &cobra.Command{
 		opts.Password = viper.GetString("password")
 		opts.Output = viper.GetString("output")
 		opts.Overwrite = viper.GetBool("overwrite")
+		opts.SkipCTFDCheck = viper.GetBool("skip-check")
 
 		baseURL, err := url.Parse(opts.URL)
 		CheckErr(err)
@@ -59,8 +60,10 @@ var ctfdWriteupCmd = &cobra.Command{
 
 		client.Creds = &credentials
 
-		err = ctfd.Check()
-		CheckErr(err)
+		if !opts.SkipCTFDCheck {
+			err = ctfd.Check()
+			CheckErr(err)
+		}
 
 		err = ctfd.Authenticate()
 		CheckErr(err)

--- a/cmd/ctfd-writeups.go
+++ b/cmd/ctfd-writeups.go
@@ -59,6 +59,9 @@ var ctfdWriteupCmd = &cobra.Command{
 
 		client.Creds = &credentials
 
+		err = ctfd.Check()
+		CheckErr(err)
+
 		err = ctfd.Authenticate()
 		CheckErr(err)
 

--- a/cmd/ctfd.go
+++ b/cmd/ctfd.go
@@ -30,6 +30,7 @@ func init() {
 
 	ctfdCmd.PersistentFlags().BoolVarP(&opts.Overwrite, "overwrite", "", false, "Overwrite existing files")
 	ctfdCmd.PersistentFlags().BoolVarP(&opts.SaveConfig, "save-config", "", false, "Save config to (default is $OUTDIR/.ctftool.yaml)")
+	ctfdCmd.PersistentFlags().BoolVarP(&opts.SkipCTFDCheck, "skip-check", "", false, "Skip CTFd instance check")
 
 	// viper
 	err := viper.BindPFlag("url", ctfdCmd.Flags().Lookup("url"))
@@ -45,5 +46,8 @@ func init() {
 	CheckErr(err)
 
 	err = viper.BindPFlag("overwrite", ctfdCmd.PersistentFlags().Lookup("overwrite"))
+	CheckErr(err)
+
+	err = viper.BindPFlag("skip-check", ctfdCmd.PersistentFlags().Lookup("skip-check"))
 	CheckErr(err)
 }

--- a/pkg/ctfd/ctfd.go
+++ b/pkg/ctfd/ctfd.go
@@ -24,7 +24,7 @@ func Check() error {
 	// make a request to https://demo.ctfd.io/api/v1/challenges
 	resp, err := client.GetJson(fmt.Sprintf("%s/api/v1/challenges", client.BaseURL.String()))
 	if err != nil {
-		return err
+		return fmt.Errorf("cant reach CTFd instance: %s", err)
 	}
 
 	// Check if the response is not OK

--- a/pkg/ctfd/ctfd.go
+++ b/pkg/ctfd/ctfd.go
@@ -1,6 +1,7 @@
 package ctfd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -8,7 +9,6 @@ import (
 	"net/url"
 	"path"
 	"regexp"
-	"strings"
 
 	"github.com/ritchies/ctftool/pkg/scraper"
 )
@@ -21,32 +21,34 @@ func NewClient() *scraper.Client {
 
 // Check will check if the instance is a CTFd instance.
 func Check() error {
-	doc, err := client.GetDoc(client.BaseURL.String())
+	// make a request to https://demo.ctfd.io/api/v1/challenges
+	resp, err := client.GetJson(fmt.Sprintf("%s/api/v1/challenges", client.BaseURL.String()))
 	if err != nil {
 		return err
 	}
 
-	// Check for "<small class="text-muted">Powered by CTFd</small>"
-	footerText := doc.Find("small.text-muted").Text()
-	if !strings.Contains(footerText, "Powered by CTFd") {
-		return errors.New("not a CTFd instance")
+	// Check if the response is not OK
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to check: %s", resp.Status)
 	}
 
-	// check /login
-	/* 	doc, err = c.get(c.BaseURL.String() + "/login")
-	   	if err != nil {
-	   		return err
-	   	} */
+	// Read the response body
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
 
-	// Check if there are captcha's on the login page
-	/* 	captchaURLs := []string{"https://www.google.com/recaptcha/api.js", "https://hcaptcha.com/1/api.js"}
-	   	for _, captchaURL := range captchaURLs {
-	   		if doc.Find("script[src]").FilterFunction(func(i int, s *goquery.Selection) bool {
-	   			return strings.Contains(s.AttrOr("src", ""), captchaURL)
-	   		}).Length() > 0 {
-	   			return fmt.Errorf("captcha detected on login page")
-	   		}
-	   	} */
+	// Parse the response as JSON
+	var response map[string]interface{}
+	err = json.Unmarshal(data, &response)
+	if err != nil {
+		return err
+	}
+
+	// Check if the response contains the "success" field
+	if _, ok := response["success"]; !ok {
+		return errors.New("not a CTFd instance")
+	}
 
 	return nil
 }
@@ -54,10 +56,6 @@ func Check() error {
 // Authenticate will attempt to authenticate the client with the provided
 // username and password.
 func Authenticate() error {
-	if err := Check(); err != nil {
-		return err
-	}
-
 	setPassword := func(values url.Values) {
 		values.Set("name", client.Creds.Username)
 		values.Set("password", client.Creds.Password)

--- a/pkg/ctfd/ctfd_opts.go
+++ b/pkg/ctfd/ctfd_opts.go
@@ -1,12 +1,13 @@
 package ctfd
 
 type CTFOpts struct {
-	URL        string
-	Username   string
-	Password   string
-	Output     string
-	Overwrite  bool
-	SaveConfig bool
+	URL           string
+	Username      string
+	Password      string
+	Output        string
+	Overwrite     bool
+	SaveConfig    bool
+	SkipCTFDCheck bool
 }
 
 // NewOptions returns a new Options struct

--- a/pkg/ctfd/ctfd_test.go
+++ b/pkg/ctfd/ctfd_test.go
@@ -34,14 +34,15 @@ func copyTestFile(w io.Writer, filename string) error {
 }
 
 func TestCheck(t *testing.T) {
+	// test if check returns nil when the response is valid (200) ok
 	tests := []struct {
 		description string
-		html        string
+		htmlFile    string
 		expected    bool
 	}{
 		{
-			"ctfd instance",
-			`<html><body><small class="text-muted">Powered by CTFd</small></body></html>`,
+			"check",
+			"challenges.json",
 			true,
 		},
 	}
@@ -52,13 +53,12 @@ func TestCheck(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s mux", test.description), func(t *testing.T) {
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, err := w.Write([]byte(test.html))
-				if err != nil {
-					t.Errorf("Write() returned error: %v", err)
+				if err := copyTestFile(w, test.htmlFile); err != nil {
+					t.Errorf("copyTestFile() returned error: %v", err)
 				}
 			})
 		})
+
 		t.Run(fmt.Sprintf("%s check", test.description), func(t *testing.T) {
 			err := Check()
 			if err != nil {
@@ -67,39 +67,6 @@ func TestCheck(t *testing.T) {
 		})
 	}
 }
-
-// test Check for error
-/* func TestCheckFail(t *testing.T) {
-	tests := []struct {
-		description  string
-		responseBody string
-		expected     bool
-	}{
-		{
-			"check fail",
-			`<html><body><small class="text-muted">Not Powered by CTFd</small></body></html>`,
-			false,
-		},
-	}
-
-	client, mux, cleanup := setup()
-	defer cleanup()
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%s mux", test.description), func(t *testing.T) {
-			mux.HandleFunc("/nope", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write([]byte(test.responseBody))
-			})
-
-			err := client.Check()
-			if err == nil {
-				t.Errorf("Check() returned no error")
-			}
-
-		})
-	}
-} */
 
 // Test Check Failure
 func TestCheckFailure(t *testing.T) {

--- a/pkg/ctfd/testdata/challenges.json
+++ b/pkg/ctfd/testdata/challenges.json
@@ -1,0 +1,33 @@
+{
+    "success": true,
+    "data": [
+        {
+            "id": 1,
+            "type": "dynamic",
+            "name": "More Challenges Tomorrow!",
+            "value": 0,
+            "solves": 0,
+            "solved_by_me": false,
+            "category": "Welcome",
+            "tags": [],
+            "template": "/plugins/dynamic_challenges/assets/view.html",
+            "script": "/plugins/dynamic_challenges/assets/view.js"
+        },
+        {
+            "id": 2,
+            "type": "dynamic",
+            "name": "HumanTwo",
+            "value": 50,
+            "solves": 725,
+            "solved_by_me": false,
+            "category": "Misc",
+            "tags": [
+                {
+                    "value": "easy"
+                }
+            ],
+            "template": "/plugins/dynamic_challenges/assets/view.html",
+            "script": "/plugins/dynamic_challenges/assets/view.js"
+        }
+    ]
+}

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -128,6 +128,16 @@ func (c *Client) GetJson(urlStr string, a ...interface{}) (*http.Response, error
 		return nil, err
 	}
 
+	// Set headers
+	headers := map[string]string{
+		"Accept": "application/json",
+	}
+
+	// Set the request headers using the SetHeaders method.
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
 	// Perform the request using the Client's DoRequest method.
 	resp, err := c.DoRequest(req)
 	if err != nil {


### PR DESCRIPTION
#### Summary
Introduces the `--skip-check` flag across various command-line options to skip the CTFd instance validation. It also refactors how CTFd instance validation is performed by replacing HTML scraping with API calls for improved reliability.

#### Changes

1. **New Feature**: Added `--skip-check` flag to `ctfdDownloadCmd`, `ctfdSubmitCmd`, and `ctfdWriteupCmd`. This allows users to skip the CTFd instance validation check when using these commands.

    - Files Affected:
        - `cmd/ctfd-download.go`
        - `cmd/ctfd-submit.go`
        - `cmd/ctfd-writeups.go`

2. **Refactor**: Replaced the CTFd instance check from HTML scraping to API calls for more robust and faster validation.

    - Files Affected:
        - `pkg/ctfd/ctfd.go`

3. **Code Cleanup**: Removed commented-out code and unnecessary comments.

    - Files Affected:
        - `pkg/ctfd/ctfd_test.go`

4. **Tests**: Updated unit tests to align with the new validation method and added test data.

    - Files Affected:
        - `pkg/ctfd/ctfd_test.go`
        - `pkg/ctfd/testdata/challenges.json`

5. **Minor**: Added headers to the JSON request in the scraper package.

    - Files Affected:
        - `pkg/scraper/scraper.go`