### PR TITLE
Add Watch Feature

### DIFF
--- a/pkg/ctfd/ctfd_opts.go
+++ b/pkg/ctfd/ctfd_opts.go
@@ -1,5 +1,7 @@
 package ctfd
 
+import "time"
+
 type CTFOpts struct {
 	URL           string
 	Username      string
@@ -8,6 +10,8 @@ type CTFOpts struct {
 	Overwrite     bool
 	SaveConfig    bool
 	SkipCTFDCheck bool
+	Watch         bool
+	WatchInterval time.Duration
 }
 
 // NewOptions returns a new Options struct


### PR DESCRIPTION
This PR introduces a `--watch` feature that enables the `ctfd download` command to monitor for new challenges at a specified interval. It also refines the codebase, specifically within the `ctfd download` command, to improve its structure and user interaction.

#### Key Changes:

1. **New Feature**: Added `--watch` and `--watch-interval` flags to the `ctfd download` command. These flags allow the user to watch for new CTF challenges and set the watch interval, respectively.
    - Files Affected:
        - `cmd/ctfd-download.go`
        - `pkg/ctfd/ctfd_opts.go`

2. **Code Refactor**: Moved the challenge processing logic into a separate function named `processChallenges` for better code organization.
    - Files Affected:
        - `cmd/ctfd-download.go`

3. **Code Cleanup**: Minor cleanups including the removal of unnecessary comments and the addition of more meaningful log messages.
    - Files Affected:
        - `cmd/ctfd-download.go`