### PR TITLE
Add unsolved parameter

### DIFF
--- a/pkg/ctfd/ctfd_opts.go
+++ b/pkg/ctfd/ctfd_opts.go
@@ -10,6 +10,7 @@ type CTFOpts struct {
 	Overwrite     bool
 	SaveConfig    bool
 	SkipCTFDCheck bool
+	UnsolvedOnly  bool
 	Watch         bool
 	WatchInterval time.Duration
 }


### PR DESCRIPTION
Introduces a new `--unsolved` flag to the `ctfd download` command, allowing users to focus on downloading only the challenges that they haven't solved yet.

#### Key Changes:

1. **New Feature**: Added a `--unsolved` flag to the `ctfd download` command. When this flag is set, the command will only download challenges that the user has not yet solved.
    - Files Affected:
        - `cmd/ctfd-download.go`
        - `pkg/ctfd/ctfd_opts.go`