### PR TITLE
Fix goreleaser deprecated replacements

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,12 +38,14 @@ builds:
 archives:
   - id: tgz
     format: tar.gz
-    #name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      linux: Linux
-      darwin: macOS
-      windows: Windows
-      386: i386
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- if eq .Os "linux" }}Linux
+      {{- else if eq .Os "darwin" }}macOS
+      {{- else if eq .Os "windows" }}Windows
+      {{- else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: "windows"
         format: "zip"

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ tidy: ## go mod tidy on the source files
 
 check: fmt vet tidy
 	go test ./... -short
+	goreleaser check
 
 test: vet ## run short unit tests
 	go test -v ./... -short


### PR DESCRIPTION
Goreleaser has deprecated the replacements feature, and now uses a template form to do the same task.

#### References

https://goreleaser.com/deprecations/?h=replacements#archivesreplacements