### PR TITLE
Implement CTFd API Token Authentication Across Commands

### DIFF
--- a/cmd/ctfd-submit.go
+++ b/cmd/ctfd-submit.go
@@ -26,6 +26,7 @@ var ctfdSubmitCmd = &cobra.Command{
 		opts.URL = viper.GetString("url")
 		opts.Username = viper.GetString("username")
 		opts.Password = viper.GetString("password")
+		opts.Token = viper.GetString("token")
 		opts.SkipCTFDCheck = viper.GetBool("skip-check")
 
 		baseURL, err := url.Parse(opts.URL)
@@ -52,14 +53,14 @@ var ctfdSubmitCmd = &cobra.Command{
 			opts.Password = strings.TrimSpace(password)
 		}
 
-		// opts.Username and password are required
-		if opts.Username == "" || opts.Password == "" {
-			ShowHelp(cmd, "CTFD User and Password are required")
+		if (opts.Username == "" || opts.Password == "") && opts.Token == "" {
+			ShowHelp(cmd, "Either CTFD Username and Password or a Token are required")
 		}
 
 		credentials := scraper.Credentials{
 			Username: opts.Username,
 			Password: opts.Password,
+			Token:    opts.Token,
 		}
 
 		client.Creds = &credentials
@@ -69,10 +70,12 @@ var ctfdSubmitCmd = &cobra.Command{
 			CheckErr(err)
 		}
 
-		err = ctfd.Authenticate()
-		CheckErr(err)
+		if (opts.Username != "" || opts.Token != "") && opts.Password == "" {
+			err = ctfd.Authenticate()
+			CheckErr(err)
 
-		log.Infof("Authenticated as %q", opts.Username)
+			log.Infof("Authenticated as %q", opts.Username)
+		}
 
 		submission := ctfd.Submission{
 			ID:   CTFDSubmissionID,
@@ -92,6 +95,7 @@ func init() {
 	ctfdSubmitCmd.Flags().StringVarP(&opts.URL, "url", "", "", "CTFd URL")
 	ctfdSubmitCmd.Flags().StringVarP(&opts.Username, "username", "u", "", "CTFd Username")
 	ctfdSubmitCmd.Flags().StringVarP(&opts.Password, "password", "p", "", "CTFd Password")
+	ctfdSubmitCmd.Flags().StringVarP(&opts.Token, "token", "t", "", "CTFd Token")
 
 	ctfdSubmitCmd.Flags().IntVarP(&CTFDSubmissionID, "id", "i", 0, "CTFd Submission ID")
 	ctfdSubmitCmd.Flags().StringVarP(&CTFDSubmission, "submission", "s", "", "Submission")
@@ -104,5 +108,8 @@ func init() {
 	CheckErr(err)
 
 	err = viper.BindPFlag("password", ctfdSubmitCmd.Flags().Lookup("password"))
+	CheckErr(err)
+
+	err = viper.BindPFlag("token", ctfdSubmitCmd.Flags().Lookup("token"))
 	CheckErr(err)
 }

--- a/pkg/ctfd/ctfd_opts.go
+++ b/pkg/ctfd/ctfd_opts.go
@@ -6,6 +6,7 @@ type CTFOpts struct {
 	URL           string
 	Username      string
 	Password      string
+	Token         string
 	Output        string
 	Overwrite     bool
 	SaveConfig    bool

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -25,6 +25,7 @@ type Client struct {
 type Credentials struct {
 	Username string
 	Password string
+	Token    string
 }
 
 // NewClient returns a new instance of the Client struct with a specified transport.
@@ -159,6 +160,11 @@ func (c *Client) GetJson(urlStr string, a ...interface{}) (*http.Response, error
 func (c *Client) DoRequest(req *http.Request) (*http.Response, error) {
 	// Create a new rate limiter with a limit of 1 request per second.
 	rl := ratelimit.New(1)
+
+	// Set Authorization header if token is not empty.
+	if c.Creds.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.Creds.Token))
+	}
 
 	// Perform the request and capture the response and error.
 	resp, err := c.Client.Do(req)


### PR DESCRIPTION
Introduces API token-based authentication as an alternative to username/password-based authentication for interacting with CTFd. Users can now use either their username/password or an API token to authenticate.

#### Key Changes:

1. **New Feature**: Added support for API token-based authentication.
    - Users can now authenticate using an API token instead of just the username and password.
    - This is supported across multiple commands (`ctfd-download`, `ctfd-submit`, `ctfd-writeups`).
  
2. **Code Refactoring**: Updated the `Credentials` and `CTFOpts` structs to include a `Token` field.

3. **Validation**: Added conditions to check that either a username/password or a token must be provided for authentication.

4. **Configuration**: The token can be saved in the configuration file, similar to the username and password.